### PR TITLE
AngularJS $destroy event not fired

### DIFF
--- a/angular-kendo-window.js
+++ b/angular-kendo-window.js
@@ -82,6 +82,8 @@ angular.module('kendo.window', [])
                         closeFunction();
                         windowInstance.deferred.reject();
                         setTimeout(function(){
+                            //Add close call to allow controller to $destroy correctly
+                            windowInstance.modalScope.$close();
             				scope.myKendoWindow.destroy();
             			}, 1000);
                     }    
@@ -90,6 +92,8 @@ angular.module('kendo.window', [])
                     windowInstance.options.close = function(e){
                         windowInstance.deferred.reject();
                         setTimeout(function(){
+                            //Add close call to allow controller to $destroy correctly
+                            windowInstance.modalScope.$close();
             				scope.myKendoWindow.destroy();
             			}, 1000);
                     }


### PR DESCRIPTION
Using the kendo window 'x' title bar control to close the window causes the window based controller to miss an opportunity at running $destroy. This is a resource leak.
Fixes kjartanvalur/angular-kendo-window#22